### PR TITLE
Support json

### DIFF
--- a/src/catalog_provider/glue.rs
+++ b/src/catalog_provider/glue.rs
@@ -25,6 +25,7 @@ use datafusion::catalog::catalog::CatalogProvider;
 use datafusion::catalog::schema::{ObjectStoreSchemaProvider, SchemaProvider};
 use datafusion::datasource::file_format::avro::AvroFormat;
 use datafusion::datasource::file_format::csv::CsvFormat;
+use datafusion::datasource::file_format::json::JsonFormat;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::file_format::FileFormat;
 use datafusion::datasource::listing::{ListingOptions, ListingTableConfig};
@@ -32,7 +33,6 @@ use datafusion_objectstore_s3::object_store::s3::S3FileSystem;
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
-use datafusion::datasource::file_format::json::JsonFormat;
 
 /// `CatalogProvider` implementation for the Amazon Glue API
 pub struct GlueCatalogProvider {

--- a/src/catalog_provider/glue.rs
+++ b/src/catalog_provider/glue.rs
@@ -257,10 +257,18 @@ impl GlueCatalogProvider {
             (
                 "org.apache.hadoop.mapred.TextInputFormat",
                 "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                "org.apache.hive.hcatalog.data.JsonSerDe",
+            ) => Ok(Box::new(JsonFormat::default())),
+            (
+                "org.apache.hadoop.mapred.TextInputFormat",
+                "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
                 "org.openx.data.jsonserde.JsonSerDe",
-            ) => {
-                Ok(Box::new(JsonFormat::default()))
-            }
+            ) => Ok(Box::new(JsonFormat::default())),
+            (
+                "org.apache.hadoop.mapred.TextInputFormat",
+                "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                "com.amazon.ionhiveserde.IonHiveSerDe",
+            ) => Ok(Box::new(JsonFormat::default())),
             _ => Err(GlueError::NotImplemented(format!(
                 "No support for: {}, {}, {:?} yet.",
                 input_format, output_format, sd

--- a/src/catalog_provider/glue.rs
+++ b/src/catalog_provider/glue.rs
@@ -32,6 +32,7 @@ use datafusion_objectstore_s3::object_store::s3::S3FileSystem;
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
+use datafusion::datasource::file_format::json::JsonFormat;
 
 /// `CatalogProvider` implementation for the Amazon Glue API
 pub struct GlueCatalogProvider {
@@ -253,6 +254,13 @@ impl GlueCatalogProvider {
                 "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat",
                 "org.apache.hadoop.hive.serde2.avro.AvroSerDe",
             ) => Ok(Box::new(AvroFormat::default())),
+            (
+                "org.apache.hadoop.mapred.TextInputFormat",
+                "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                "org.openx.data.jsonserde.JsonSerDe",
+            ) => {
+                Ok(Box::new(JsonFormat::default()))
+            }
             _ => Err(GlueError::NotImplemented(format!(
                 "No support for: {}, {}, {:?} yet.",
                 input_format, output_format, sd


### PR DESCRIPTION
Handles #8 

Works on files which look like this:

```json
{"a":1, "b":2.0, "c":false, "d":"4"}
{"a":-10, "b":-3.5, "c":true, "d":"4"}
{"a":2, "b":0.6, "c":false, "d":"text"}
{"a":1, "b":2.0, "c":false, "d":"4"}
{"a":7, "b":-3.5, "c":true, "d":"4"}
{"a":1, "b":0.6, "c":false, "d":"text"}
```

Does not work on files which are a single json array:

```json
[
{"a":1, "b":2.0, "c":false, "d":"4"},
{"a":-10, "b":-3.5, "c":true, "d":"4"},
{"a":2, "b":0.6, "c":false, "d":"text"}
]
```